### PR TITLE
Revert "MAX-33319 The window slave is 64-bit."

### DIFF
--- a/lib/getSystem.js
+++ b/lib/getSystem.js
@@ -8,7 +8,7 @@ function getSystem() {
       result = 'linux';
       break;
     case 'windows':
-      result = 'win64';
+      result = 'win32';
       break;
     default:
       result = 'darwin';


### PR DESCRIPTION
Reverts ServiceMax-Engineering/neocore-selenium-drivers#19